### PR TITLE
fix requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ pytest-runner>=3.0.0,<3.1.0
 pytest>=3.2.0,<3.3.0
 readme-renderer>=24.0
 setuptools>=40.6.2
-git+git://github.com/sceptre/sceptre-core.git@master#egg=sceptre-core
+git+git://github.com/sceptre/sceptre.git@master#egg=sceptre
 tox>=2.9.1,<3.0.0
 twine>=1.12.1
 wheel==0.32.3


### PR DESCRIPTION
I've found that Resolvers need to import more modules than what's
available in sceptre-core.