### PR TITLE
 Update template repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: sceptreorg/sceptre-circleci:0.8.0
+      - image: sceptreorg/sceptre-circleci:2.0.0
 
     steps:
       - checkout
@@ -13,24 +13,17 @@ jobs:
             v1-dependency-cache-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}
 
       - run:
-          name: Install Dependencies
+          name: Install
           command: |
-            python3 -m venv venv
-            . venv/bin/activate
-            pip3 install --upgrade pip
-            pip3 install -r requirements.txt
+            pyenv virtualenv 3.9.4 venv
+            pyenv global venv
+            make install-dev
 
       - save_cache:
           key:
             v1-dependency-cache-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}
           paths:
             - 'venv'
-
-      - run:
-          name: Install Resolver
-          command: |
-            . venv/bin/activate
-            pip3 install -e .
 
       - persist_to_workspace:
           root: /home/circleci
@@ -39,7 +32,7 @@ jobs:
 
   lint-and-unit-test:
     docker:
-      - image: sceptreorg/sceptre-circleci:0.8.0
+      - image: sceptreorg/sceptre-circleci:2.0.0
 
     steps:
       - attach_workspace:
@@ -54,10 +47,9 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            python3 -m venv venv
-            . venv/bin/activate
-            pip3 install --upgrade pip
-            pip3 install -r requirements.txt
+            pyenv virtualenv 3.9.4 venv
+            pyenv global venv
+            make install-dev
 
       - save_cache:
           key:
@@ -68,29 +60,23 @@ jobs:
       - run:
           name: Linting
           command: |
-            . venv/bin/activate
+            pyenv global venv
             make lint
 
       - run:
           name: Unit Test
           command: |
-            . venv/bin/activate
-            mkdir test-reports
-            make test
+            pyenv global venv
+            make test-all
 
       - run:
           name: Coverage
           command: |
-            . venv/bin/activate
+            pyenv global venv
             make coverage
 
       - store_test_results:
           path: test-reports
-          destination: test-reports
-
-      - store_test_results:
-          path: coverage.xml
-          destination: coverage-reports
 
       - store_artifacts:
           path: test-reports
@@ -107,17 +93,16 @@ jobs:
 
   deploy-test:
     docker:
-      - image: sceptreorg/sceptre-circleci:0.8.0
+      - image: sceptreorg/sceptre-circleci:2.0.0
 
     steps:
       - checkout
       - run:
           name: Install Dependencies
           command: |
-            python3 -m venv venv
-            . venv/bin/activate
-            pip3 install --upgrade pip
-            pip3 install -r requirements.txt
+            pyenv virtualenv 3.9.4 venv
+            pyenv global venv
+            make install-dev
 
           paths:
             - 'venv'
@@ -134,28 +119,27 @@ jobs:
       - run:
           name: Create Distribution
           command: |
-            . venv/bin/activate
+            pyenv global venv
             make dist
 
       - run:
           name: Upload to PyPi
           command: |
-            . venv/bin/activate
+            pyenv global venv
             twine upload -r test-pypi dist/*
 
   deploy-production:
     docker:
-      - image: sceptreorg/sceptre-circleci:0.8.0
+      - image: sceptreorg/sceptre-circleci:2.0.0
 
     steps:
       - checkout
       - run:
           name: Install Dependencies
           command: |
-            python3 -m venv venv
-            . venv/bin/activate
-            pip3 install --upgrade pip
-            pip3 install -r requirements.txt
+            pyenv virtualenv 3.9.4 venv
+            pyenv global venv
+            make install-dev
 
           paths:
             - 'venv'
@@ -171,13 +155,13 @@ jobs:
       - run:
           name: Create Distribution
           command: |
-            . venv/bin/activate
+            pyenv global venv
             make dist
 
       - run:
           name: Upload to PyPi
           command: |
-            . venv/bin/activate
+            pyenv global venv
             twine upload -r pypi dist/*
 workflows:
   test:

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,16 @@
+[flake8]
+exclude =
+	.git,
+	__pycache__,
+	build,
+	dist,
+	.tox,
+	venv,
+	.venv,
+	.pytest_cache
+max-complexity = 12
+per-file-ignores =
+	docs/_api/conf.py: E265
+	integration-tests/steps/*: E501,F811,F403,F405
+extend-ignore = E203
+max-line-length = 120

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.python-version
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,13 +3,40 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.4.0
     hooks:
       - id: end-of-file-fixer
       - id: mixed-line-ending
       - id: trailing-whitespace
-
   - repo: https://github.com/PyCQA/flake8
-    rev: 3.9.2
+    rev: 6.0.0
     hooks:
       - id: flake8
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.29.0
+    hooks:
+      - id: yamllint
+  - repo: https://github.com/awslabs/cfn-python-lint
+    rev: v0.72.10
+    hooks:
+      - id: cfn-python-lint
+        args:
+          - "-i=E0000"
+          - "-i=E1001"
+          - "-i=E3012"
+          - "-i=W6001"
+        exclude: |
+          (?x)(
+            ^temp/|
+            ^.circleci/|
+            ^.pre-commit-config.yaml
+          )
+  - repo: https://github.com/psf/black
+    rev: 23.1.0
+    hooks:
+      - id: black
+        # It is recommended to specify the latest version of Python
+        # supported by your project here, or alternatively use
+        # pre-commit's default_language_version, see
+        # https://pre-commit.com/#top_level-default_language_version
+        language_version: python3.10

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,27 @@
+---
+
+extends: default
+
+rules:
+  braces:
+    level: warning
+    max-spaces-inside: 1
+  brackets:
+    level: warning
+    max-spaces-inside: 1
+  commas:
+    level: warning
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    level: warning
+  hyphens:
+    level: warning
+  indentation:
+    level: warning
+    indent-sequences: consistent
+  line-length: disable
+  truthy: disable
+  new-line-at-end-of-file:
+    level: warning

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,31 @@
+install: clean
+	pip install .
+
+install-dev: clean
+	pip install -r requirements.txt
+	pip install -r requirements-dev.txt
+	pip install -e .
+
 coverage-all:
-		coverage erase
-		coverage run --source resolver -m unittest
-		coverage xml
+	coverage erase
+	coverage run --source resolver -m unittest
+	coverage xml
 
 coverage: coverage-all
-		coverage report --show-missing
+	coverage report --show-missing
 
 test:
-	    python -m pytest --junitxml=test-reports/junit.xml
+	python -m pytest --junitxml=test-reports/junit.xml
+
+test-all:
+	tox --parallel=auto
+
 lint:
-	    pre-commit run --all-files --show-diff-on-failure
+	pre-commit run --all-files --show-diff-on-failure
 
 dist: clean
-	python3 setup.py sdist
-	python3 setup.py bdist_wheel
+	python setup.py sdist
+	python setup.py bdist_wheel
 	twine check dist/*
 	ls -l dist
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = ["setuptools", "wheel"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,11 @@
+bumpversion>=0.5.3,<0.6.0
+coverage>=5.1,<6.0
+flake8>=3.9.1,<4.0.0
+pre-commit>=2.12.0,<2.13
+pytest>=6.2.0,<7.0.0
+pytest-cov>=2.11.1,<3.0.0
+readme-renderer>=24.0,<25.0
+setuptools==65.5.1
+tox>=3.23,<4.0
+twine>=1.12.1,<2.0
+wheel==0.38.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,1 @@
-bumpversion==0.5.3
-coverage==4.4.2
-mock==2.0.0
-pre-commit>=2.12.0,<2.13
-pytest-runner>=3.0.0,<3.1.0
-pytest>=3.2.0,<3.3.0
-readme-renderer>=24.0
-setuptools>=40.6.2
-sceptre>=2.7
-tox>=2.9.1,<3.0.0
-twine>=1.12.1
-wheel==0.32.3
+sceptre>=3.2

--- a/resolver/resolver.py
+++ b/resolver/resolver.py
@@ -2,8 +2,6 @@ from sceptre.resolvers import Resolver
 
 
 class CustomResolver(Resolver):
-    def __init__(self, *args, **kwargs):
-        super(CustomResolver, self).__init__(*args, **kwargs)
 
     def resolve(self):
         """

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,4 +23,4 @@ exclude =
 	dist,
 	.tox,
 	venv
-max-line-length = 99
+max-line-length = 120

--- a/setup.py
+++ b/setup.py
@@ -6,35 +6,33 @@ __version__ = "0.0.1"
 # https://github.com/Sceptre/project/wiki/sceptre-resolver-template
 
 # lowercase, use `-` as separator.
-RESOLVER_NAME = 'sceptre-resolver-template'
+RESOLVER_NAME = "sceptre-resolver-template"
 # the resolver call in sceptre e.g. !command_name.
-RESOLVER_COMMAND_NAME = 'custom_resolver'
+RESOLVER_COMMAND_NAME = "custom_resolver"
 # do not change. Rename resolver/resolver.py to resolver/{RESOLVER_COMMAND_NAME}.py
-RESOLVER_MODULE_NAME = 'resolver.{}'.format(RESOLVER_COMMAND_NAME)
+RESOLVER_MODULE_NAME = "resolver.{}".format(RESOLVER_COMMAND_NAME)
 # CamelCase name of resolver class in resolver.resolver.
-RESOLVER_CLASS = 'CustomResolver'
+RESOLVER_CLASS = "CustomResolver"
 # One line summary description
-RESOLVER_DESCRIPTION = ''
+RESOLVER_DESCRIPTION = ""
 # if multiple use a single string with comma separated names.
-RESOLVER_AUTHOR = 'Sceptre'
+RESOLVER_AUTHOR = "Sceptre"
 # if multiple use single string with commas.
-RESOLVER_AUTHOR_EMAIL = 'sceptre@cloudreach.com'
-RESOLVER_URL = 'https://github.com/sceptre/{}'.format(RESOLVER_NAME)
+RESOLVER_AUTHOR_EMAIL = "sceptreorg@gmail.com"
+RESOLVER_URL = "https://github.com/sceptre/{}".format(RESOLVER_NAME)
 
 with open("README.md") as readme_file:
     README = readme_file.read()
 
 install_requirements = [
-    "sceptre>=2.7",
+    "sceptre>=4.0",
 ]
 
 test_requirements = [
-    "pytest>=3.2",
+    "pytest>=6.0",
 ]
 
-setup_requirements = [
-    "pytest-runner>=3"
-]
+setup_requirements = ["pytest-runner>=6.0"]
 
 setup(
     name=RESOLVER_NAME,
@@ -44,15 +42,15 @@ setup(
     long_description_content_type="text/markdown",
     author=RESOLVER_AUTHOR,
     author_email=RESOLVER_AUTHOR_EMAIL,
-    license='Apache2',
+    license="Apache2",
     url=RESOLVER_URL,
-    packages=find_packages(
-        exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
+    packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     py_modules=[RESOLVER_MODULE_NAME],
     entry_points={
-        'sceptre.resolvers': [
-            "{}={}:{}".format(RESOLVER_COMMAND_NAME,
-                              RESOLVER_MODULE_NAME, RESOLVER_CLASS)
+        "sceptre.resolvers": [
+            "{}={}:{}".format(
+                RESOLVER_COMMAND_NAME, RESOLVER_MODULE_NAME, RESOLVER_CLASS
+            )
         ]
     },
     include_package_data=True,
@@ -62,16 +60,14 @@ setup(
         "Intended Audience :: Developers",
         "Natural Language :: English",
         "Environment :: Console",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7"
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     test_suite="tests",
     install_requires=install_requirements,
     tests_require=test_requirements,
     setup_requires=setup_requirements,
-    extras_require={
-        "test": test_requirements
-    }
+    extras_require={"test": test_requirements},
 )

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with open("README.md") as readme_file:
     README = readme_file.read()
 
 install_requirements = [
-    "sceptre>=4.0",
+    "sceptre>=3.2",
 ]
 
 test_requirements = [

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,4 +1,3 @@
-
 class TestStackActions(object):
     def setup_method(self, test_method):
         pass

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,14 @@
+[tox]
+minversion = 3.23.0
+isolated_build = True
+envlist = py{37,38,39,310},flake8
+skip_missing_interpreters = True
+
+[testenv]
+deps =
+     -rrequirements.txt
+     -rrequirements-dev.txt
+commands = pytest {posargs: --junitxml=test-reports/junit-{envname}.xml}
+
+[testenv:flake8]
+commands = flake8 .


### PR DESCRIPTION
This is a change to keep this repo updated with Sceptre Core.
It's also a partial solution to issue https://github.com/Sceptre/sceptre/issues/1298

    * update docker image to "image: sceptreorg/sceptre-circleci:2.0.0"
    * update pre-commit linters to match sceptre core linters
    * update supported Programming Language in setup.py
    * update to install requirements.txt and requirements-dev.txt
    * update max-line-length in setup.cfg to 120
    * remove unittest in favor of pytest
    * update makefile
    * change calls to `pip3` to just `pip`
    * change calls to `python3` to just `python`
    * update tox to test with multiple python versions
    * update to use flake8
    * use pyenv to setup virtualenv for CI builds
    * add pyproject.toml, for some reason tox needs it.
 