### PR TITLE
Fix pre-commit and poetry with tox

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     hooks:
       - id: yamllint
   - repo: https://github.com/awslabs/cfn-python-lint
-    rev: v0.76.1
+    rev: v0.76.2
     hooks:
       - id: cfn-python-lint
         args:
@@ -45,7 +45,8 @@ repos:
     hooks:
       - id: poetry-check
       - id: poetry-lock
+        language_version: python3.10
   - repo: https://github.com/AleksaC/circleci-cli-py
-    rev: v0.1.25085
+    rev: v0.1.25638
     hooks:
       - id: circle-ci-validator

--- a/poetry.lock
+++ b/poetry.lock
@@ -21,18 +21,18 @@ tests-no-zope = ["cloudpickle", "cloudpickle", "hypothesis", "hypothesis", "mypy
 
 [[package]]
 name = "boto3"
-version = "1.26.104"
+version = "1.26.106"
 description = "The AWS SDK for Python"
 category = "dev"
 optional = false
 python-versions = ">= 3.7"
 files = [
-    {file = "boto3-1.26.104-py3-none-any.whl", hash = "sha256:308c5a8293d9b76e74921f4d945be19cc467b92e5f128df1db76e31c71345bb3"},
-    {file = "boto3-1.26.104.tar.gz", hash = "sha256:bcd09f16bdf3d71ab7d0fab20e97242f09c63f4cea0943329521ab35a950f900"},
+    {file = "boto3-1.26.106-py3-none-any.whl", hash = "sha256:53d449bc3445da0a8812857f3e24e143dc56573bc365f36a5610900b09d06faf"},
+    {file = "boto3-1.26.106.tar.gz", hash = "sha256:bdabab7ad27ae86de22a8687cbf55d8a152c6d6f178ffb452e560bac0be957a7"},
 ]
 
 [package.dependencies]
-botocore = ">=1.29.104,<1.30.0"
+botocore = ">=1.29.106,<1.30.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.6.0,<0.7.0"
 
@@ -41,14 +41,14 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.29.104"
+version = "1.29.106"
 description = "Low-level, data-driven core of boto 3."
 category = "dev"
 optional = false
 python-versions = ">= 3.7"
 files = [
-    {file = "botocore-1.29.104-py3-none-any.whl", hash = "sha256:932bfbf580a2ae53f471df4bfbebce531985ee27468cf7c37d7ccfb3cf8bc9e4"},
-    {file = "botocore-1.29.104.tar.gz", hash = "sha256:7e7a01cef10b1daa9cb01ec25a15e831e7359fc43d1b591359710f203c3620a8"},
+    {file = "botocore-1.29.106-py3-none-any.whl", hash = "sha256:d50df9a39da1b0e475727c6c2ba141b44d9df527d3dc1936b264ee4cb1525ab7"},
+    {file = "botocore-1.29.106.tar.gz", hash = "sha256:eaaa669fe33a0ef2e9d345a98ed0befac1ea33395d63620913c1bb738c387d4d"},
 ]
 
 [package.dependencies]
@@ -628,14 +628,14 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pre-commit"
-version = "3.2.1"
+version = "3.2.2"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
 category = "dev"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pre_commit-3.2.1-py2.py3-none-any.whl", hash = "sha256:a06a7fcce7f420047a71213c175714216498b49ebc81fe106f7716ca265f5bb6"},
-    {file = "pre_commit-3.2.1.tar.gz", hash = "sha256:b5aee7d75dbba21ee161ba641b01e7ae10c5b91967ebf7b2ab0dfae12d07e1f1"},
+    {file = "pre_commit-3.2.2-py2.py3-none-any.whl", hash = "sha256:0b4210aea813fe81144e87c5a291f09ea66f199f367fa1df41b55e1d26e1e2b4"},
+    {file = "pre_commit-3.2.2.tar.gz", hash = "sha256:5b808fcbda4afbccf6d6633a56663fed35b6c2bc08096fd3d47ce197ac351d9d"},
 ]
 
 [package.dependencies]
@@ -1031,5 +1031,5 @@ test = ["covdefaults (>=2.2.2)", "coverage (>=7.1)", "coverage-enable-subprocess
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.8.1"
-content-hash = "175f40cbc151046a82bb82ad9d1df9d7aca97d1fa7481f7458f67eb61f36c075"
+python-versions = ">=3.8,<3.12"
+content-hash = "01c684f426416826f185beaf9c99f35e1e8451d0fa7b7f602e5b130a797ff7d1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,14 +15,15 @@ classifiers = [
   "Environment :: Console",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10"
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11"
 ]
 
 [tool.poetry.plugins."sceptre.resolvers"]
 "custom" = "resolver.custom:Custom"
 
 [tool.poetry.dependencies]
-python = "^3.8.1"
+python = ">=3.8,<3.12"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^3.2.1"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = true
-envlist = clean,py{38,39,310},report
+envlist = clean,py{38,39,310,311},report
 skip_missing_interpreters = true
 
 [testenv]
@@ -13,13 +13,18 @@ commands =
     poetry run pytest {posargs: --cov=resolver --cov-append --cov-report=term-missing --junitxml=test-reports/junit-{envname}.xml}
 
 [testenv:report]
-deps = coverage
 skip_install = true
+allowlist_externals = poetry
+commands_pre =
+    poetry install -v
 commands =
-    coverage report
-    coverage html
+    poetry run coverage report
+    poetry run coverage html
 
 [testenv:clean]
-deps = coverage
 skip_install = true
-commands = coverage erase
+allowlist_externals = poetry
+commands_pre =
+    poetry install -v
+commands =
+    poetry run coverage erase


### PR DESCRIPTION
* The environment for poetry was not completely setup before running tox `clean` and `report` targets. Fix by installing python dependencies for those environments and using poetry to run commands.

* i’m guessing that the circle-ci docker container used for these builds contains python 3.11 by default and tox wants to use that version really badly. Adding support for 3.11 fixes the following error on circle-ci.
```
Current Python version (3.11.1) is not allowed by the project (>=3.8,<3.11).
  Please change python executable via the "env use" command.
```