### PR TITLE
remove classifiers section

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,16 +9,6 @@ authors = ["Sceptre <sceptreorg@gmail.com>"]
 description = "A Github template for Sceptre resolvers"
 keywords = ["sceptre", "sceptre-resolver"]
 license = "Apache-2.0"
-classifiers = [
-  "Intended Audience :: Developers",
-  "Natural Language :: English",
-  "Environment :: Console",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
-  "Programming Language :: Python :: 3.12",
-]
 
 [tool.poetry.plugins."sceptre.resolvers"]
 "custom" = "resolver.custom:Custom"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,11 @@ authors = ["Sceptre <sceptreorg@gmail.com>"]
 description = "A Github template for Sceptre resolvers"
 keywords = ["sceptre", "sceptre-resolver"]
 license = "Apache-2.0"
+classifiers = [
+  "Intended Audience :: Developers",
+  "Natural Language :: English",
+  "Environment :: Console",
+]
 
 [tool.poetry.plugins."sceptre.resolvers"]
 "custom" = "resolver.custom:Custom"


### PR DESCRIPTION
Removing classifiers in poetry.toml because poetry will auto generate the classifiers[1]

[1] https://python-poetry.org/docs/pyproject/#classifiers
